### PR TITLE
COMP: Fix macOS build passing compiler paths to shape4D external project

### DIFF
--- a/SuperBuild/External_shape4D.cmake
+++ b/SuperBuild/External_shape4D.cmake
@@ -62,9 +62,18 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     SOURCE_DIR ${EP_SOURCE_DIR}
     BINARY_DIR ${EP_BINARY_DIR}
     CMAKE_CACHE_ARGS
+      # Compiler settings
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      # Output directories
+      # NA
+      # Install directories
+      # NA
+      # Dependencies
       -DSlicer_DIR:PATH=${Slicer_DIR}
+      # Options
       -D${proj}_BUILD_SLICER_EXTENSION:BOOL=ON
     INSTALL_COMMAND ""
     DEPENDS


### PR DESCRIPTION
Fix the following CMake error by ensuring the shape4D external project can be configured on system without a compiler in the PATH.

```
CMake Error at /path/to/CMake-3.22.1.app/Contents/share/cmake-3.22/Modules/CMakeTestCCompiler.cmake:69 (message):
  The C compiler
    "/dev/null"
  is not able to compile a simple test program.
```