### PR TITLE
Backport changes from branch slicersalt-2019-04-20-45cc2d4

### DIFF
--- a/RegressionComputation/RegressionComputation.py
+++ b/RegressionComputation/RegressionComputation.py
@@ -534,7 +534,7 @@ class RegressionComputationLogic(ScriptedLoadableModuleLogic, VTKObservationMixi
     # Write the parameters needed in a CSV file
     CSVInputshapesparametersfilepath = os.path.join(outputDirectory, "CSVInputshapesparameters.csv")
     file = open(CSVInputshapesparametersfilepath, 'w')
-    cw = csv.writer(file, delimiter=',')
+    cw = csv.writer(file, delimiter=',', lineterminator='\n')
     for index in range(len(parameters_sorted)):
       parameters = parameters_sorted[index]
       cw.writerow(parameters)

--- a/RegressionComputation/RegressionComputation.py
+++ b/RegressionComputation/RegressionComputation.py
@@ -517,19 +517,20 @@ class RegressionComputationLogic(ScriptedLoadableModuleLogic, VTKObservationMixi
     # Sort the shape input data according to their age
     self.sortInputCasesAges()
 
-    parameters_sorted = dict()
+    parameters_list = list()
     for row in range(table.rowCount):
-      index = self.age_list.index(table.cellWidget(row, 1).children()[1].value)
-      parameters_sorted[index] = list()
+      temp_parameters = list()
       inputshaperootname = table.cellWidget(row, 0).text
       inputshapefilepath = inputShapesDirectory + "/" + inputshaperootname + ".vtk"
-      parameters_sorted[index].append(inputshapefilepath)
+      temp_parameters.append(inputshapefilepath)
       for column in range(1, table.columnCount):
         widget = table.cellWidget(row, column)
         tuple = widget.children()
         spinbox = tuple[1]
-        parameters_sorted[index].append(spinbox.value)
+        temp_parameters.append(spinbox.value)
+      parameters_list.append(temp_parameters)
 
+    parameters_sorted = sorted(parameters_list, key=lambda x: x[1])
     # Write the parameters needed in a CSV file
     CSVInputshapesparametersfilepath = os.path.join(outputDirectory, "CSVInputshapesparameters.csv")
     file = open(CSVInputshapesparametersfilepath, 'w')

--- a/RegressionComputation/RegressionComputation.py
+++ b/RegressionComputation/RegressionComputation.py
@@ -256,7 +256,7 @@ class RegressionComputationWidget(ScriptedLoadableModuleWidget):
 
   def onInputShapesDirectoryChanged(self):
 
-    inputShapesDirectory = self.shapeInputDirectory.directory.encode('utf-8')
+    inputShapesDirectory = self.shapeInputDirectory.directory
     # Set this directory as the default output directory as well
     self.outputDirectory.directory = str(inputShapesDirectory)
 
@@ -438,11 +438,11 @@ class RegressionComputationLogic(ScriptedLoadableModuleLogic, VTKObservationMixi
 
     if sys.platform == 'win32':
       experimentName = "/ShapeRegression"
-      outputDir = self.interface.outputDirectory.directory.encode('utf-8')
+      outputDir = self.interface.outputDirectory.directory
       prefix = "/" + self.interface.outputPrefix.text
     else:
       experimentName = "ShapeRegression/"
-      outputDir = self.interface.outputDirectory.directory.encode('utf-8') + "/"
+      outputDir = self.interface.outputDirectory.directory + "/"
       prefix = self.interface.outputPrefix.text
 
     # Write XML file
@@ -491,7 +491,7 @@ class RegressionComputationLogic(ScriptedLoadableModuleLogic, VTKObservationMixi
     fileContents += "  </algorithm>\n"
     fileContents += "</experiment>\n"
 
-    XMLdriverfilepath = os.path.join(self.interface.outputDirectory.directory.encode('utf-8'), "driver.xml")
+    XMLdriverfilepath = os.path.join(self.interface.outputDirectory.directory, "driver.xml")
     f = open(XMLdriverfilepath, 'w')
     f.write(fileContents)
     f.close()
@@ -510,8 +510,8 @@ class RegressionComputationLogic(ScriptedLoadableModuleLogic, VTKObservationMixi
     self.age_list = sorted(age_list)
 
   def writeCSVInputshapesparameters(self):
-    inputShapesDirectory = self.interface.shapeInputDirectory.directory.encode('utf-8')
-    outputDirectory = self.interface.outputDirectory.directory.encode('utf-8')
+    inputShapesDirectory = self.interface.shapeInputDirectory.directory
+    outputDirectory = self.interface.outputDirectory.directory
     table = self.interface.tableWidget_inputShapeParameters
 
     # Sort the shape input data according to their age

--- a/RegressionVisualization/RegressionVisualization.py
+++ b/RegressionVisualization/RegressionVisualization.py
@@ -925,10 +925,10 @@ class RegressionVisualizationWidget(ScriptedLoadableModuleWidget):
       table1.SetValue(j, 0, float(age) )
 
       if (len(self.RegressionVolume) > 0):
-        table1.SetValue(j, 1, self.RegressionVolume[self.RegressionVolume.keys()[j]])
+        table1.SetValue(j, 1, self.RegressionVolume[list(self.RegressionVolume.keys())[j]])
       else:
         # Compute of the volume of each regression shapes
-        model = self.RegressionModels[self.RegressionModels.keys()[j]]
+        model = self.RegressionModels[list(self.RegressionModels.keys())[j]]
         polydata = model.GetPolyData()
         #triangleFilter = vtk.vtkTriangleFilter()
         #triangleFilter.SetInputData(polydata)
@@ -1053,7 +1053,7 @@ class RegressionVisualizationLogic(ScriptedLoadableModuleLogic):
     #     Number of components of the color map
     #model = RegressionModels[0]
     # We can't assume the key '0' exists in the dictionary
-    model = RegressionModels[RegressionModels.keys()[0]]
+    model = RegressionModels[list(RegressionModels.keys())[0]]
     numberOfComponents = model.GetPolyData().GetPointData().GetScalars(colormapName).GetNumberOfComponents()
     colorMapInfo.numberOfComponents = numberOfComponents
 

--- a/RegressionVisualization/RegressionVisualization.py
+++ b/RegressionVisualization/RegressionVisualization.py
@@ -336,7 +336,7 @@ class RegressionVisualizationWidget(ScriptedLoadableModuleWidget):
       warningMessagetext = "No shape regression rootname specified!"
       self.warningMessage(warningMessagetext, None)
       return
-    for shapeBasename in os.listdir(inputDirectory):
+    for shapeBasename in sorted(os.listdir(inputDirectory)):
       if not shapeBasename.find(shapesRootname) == -1 and not shapeBasename.find(".vtk") == -1:
         # Store the shape
         number_string = shapeBasename.split(shapesRootname)[1].split(".vtk")[0]

--- a/RegressionVisualization/RegressionVisualization.py
+++ b/RegressionVisualization/RegressionVisualization.py
@@ -259,7 +259,7 @@ class RegressionVisualizationWidget(ScriptedLoadableModuleWidget):
   # When the input shape directory is updated, we will try to auto populate the rootname
   def onInputShapesDirectoryChanged(self):
 
-    inputShapesDirectory = self.inputDirectoryButton.directory.encode('utf-8')
+    inputShapesDirectory = self.inputDirectoryButton.directory
 
     pathGlob = os.path.join(inputShapesDirectory, '*final_time*.vtk')
     # Search for *final_time*.vtk, which is the final sequence after estimation
@@ -330,7 +330,7 @@ class RegressionVisualizationWidget(ScriptedLoadableModuleWidget):
     self.resetSequences()
     self.resetGlobalState()
 
-    inputDirectory = self.inputDirectoryButton.directory.encode('utf-8')
+    inputDirectory = self.inputDirectoryButton.directory
     shapesRootname = self.lineEdit_shapesRootname.text
     if shapesRootname == "":
       warningMessagetext = "No shape regression rootname specified!"
@@ -407,7 +407,7 @@ class RegressionVisualizationWidget(ScriptedLoadableModuleWidget):
 
   def loadModels(self):
     """ Get models from files. Populate self.RegressionModels. """
-    inputDirectory = self.inputDirectoryButton.directory.encode('utf-8')
+    inputDirectory = self.inputDirectoryButton.directory
     for number, shapeBasename in self.InputShapes.items():
       # shapeRootname = os.path.splitext(os.path.basename(shapeBasename))[0]
       fullPath = os.path.join(inputDirectory, shapeBasename)


### PR DESCRIPTION
Integrate all changes from https://github.com/KitwareMedical/ShapeRegressionExtension/tree/slicersalt-2019-04-20-45cc2d4 expected the rename from https://github.com/KitwareMedical/ShapeRegressionExtension/commit/709b7371edcddf4234270a8a2ce2bf3f1f8090bd (`ENH: Rename modules for SALT `)