### PR TITLE
ENH: Update shape4D based on version used in Kitware/SlicerSALT@913c8644a

### DIFF
--- a/SuperBuild/External_shape4D.cmake
+++ b/SuperBuild/External_shape4D.cmake
@@ -48,7 +48,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "3f47cf711a3d21a441c1e46ea992b0f0480b5cf8" # slicersalt-2018-01-22-c74c766a4c
+    "0c53f0a0be7144806a16ddfc13e535a145d710e8" # slicersalt-2018-11-27-215f0b6
     QUIET
     )
 


### PR DESCRIPTION
:arrow_right: This change does **not** impact SlicerSALT :arrow_left: 

Since the bundling of `ShapeRegressionExtension` in SlicerSALT is done by explicitly disabling
the include of all of its external projects, this change only impact the build of `ShapeRegressionExtension` as an extension.

Indeed, at [SlicerSALT/CMakeLists.txt#L371-L386](https://github.com/Kitware/SlicerSALT/blob/913c8644a3df7cf31409279c31be8c18984e4e23/CMakeLists.txt#L371-L386), the setting `ShapeRegressionExtension_EXTERNAL_PROJECT_EXCLUDE_ALL` to `TRUE` means that `SuperBuild/External_shape4D.cmake` is not used in `SlicerSALT`.

---------

List of shape4D changes:

```
$ git shortlog 3f47cf711..0c53f0a0b --no-merges
Jared Vicory (1):
      ENH: Rename module for SALT

Jean-Christophe Fillion-Robin (7):
      COMP: Use ${PROJECT_NAME}_BUILD_SLICER_EXTENSION instead of EXTENSION_SUPERBUILD_BINARY_DIR
      COMP: Streamline integration of shape4D introducing shape4Dconfig header file
      COMP: Support disabling tests when bundling extension
      BUG: Always build shape4D CLI as an executable
      COMP: Update FFTW external project to fix integration in custom Slicer app
      ENH: Update FFTW external project to generate version and license files
      STYLE: Prefix USE_VTK and USE_SEM option with "shape4D_"
```