### PR TITLE
ENH: Update shape4D

### DIFF
--- a/SuperBuild/External_shape4D.cmake
+++ b/SuperBuild/External_shape4D.cmake
@@ -48,7 +48,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "0c53f0a0be7144806a16ddfc13e535a145d710e8" # slicersalt-2018-11-27-215f0b6
+    "4f60af717fb1af06f8e597512723abee318e140f" # slicersalt-2018-11-27-215f0b6
     QUIET
     )
 


### PR DESCRIPTION
:arrow_right: This change does **not** impact SlicerSALT :arrow_left: 

Since the bundling of `ShapeRegressionExtension` in SlicerSALT is done by explicitly disabling
the include of all of its external projects, this change only impact the build of `ShapeRegressionExtension` as an extension.

Indeed, at [SlicerSALT/CMakeLists.txt#L371-L386](https://github.com/Kitware/SlicerSALT/blob/913c8644a3df7cf31409279c31be8c18984e4e23/CMakeLists.txt#L371-L386), the setting `ShapeRegressionExtension_EXTERNAL_PROJECT_EXCLUDE_ALL` to `TRUE` means that `SuperBuild/External_shape4D.cmake` is not used in `SlicerSALT`.

----

List of shape4D changes:

```
$ git shortlog 0c53f0a0b..4f60af717 --no-merges
Jean-Christophe Fillion-Robin (8):
      COMP: Move Slicer extension packaging CMake code to top-level CMakeLists.txt
      COMP: Simplify build-system removing empty testing directory
      COMP: Simplify build-system using CMake variables prefixed with APP_
      COMP: Update minimum required CMake version from 3.5 to 3.16
      COMP: Require VTK 9
      COMP: Handle includes through usage requirements
      COMP: Support CLI build by including "shape4D.cmake" from other projects
      COMP: Display reason for enabling options shape4D_USE_VTK or shape4D_USE_SEM
```