### PR TITLE
COMP: Update shape4D to fix FFTW build ensuring compilers are passed down

### DIFF
--- a/SuperBuild/External_shape4D.cmake
+++ b/SuperBuild/External_shape4D.cmake
@@ -48,7 +48,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "4f60af717fb1af06f8e597512723abee318e140f" # slicersalt-2018-11-27-215f0b6
+    "c0ff959c73e92d6e7d1f23c68c8f5438b4d3286c" # slicersalt-2018-11-27-215f0b6
     QUIET
     )
 


### PR DESCRIPTION
Fix error like the following reported on system where CC and CXX environment variables are set to "/dev/null":

```
  checking for gcc... /dev/null
  checking whether the C compiler works... no

  configure: error: in `/path/to/ShapeRegressionExtension-build/shape4D-build/FFTW':
  configure: error: C compiler cannot create executables
  See `config.log' for more details
```

List of shape4D changes:

```
$ git shortlog 4f60af717..c0ff959c7 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix FFTW external project ensuring env is used for configuration
```